### PR TITLE
Updated docs template to allow usage on PHP installs with php short-tags turned off, and tweaked HTML

### DIFF
--- a/lib/template/layout.css
+++ b/lib/template/layout.css
@@ -73,6 +73,11 @@ h1, h2, h3, h4, h5, h6 {
         }
         #jump_page .source:first-child {
         }
+table {
+	margin: 0;
+	padding: 0;
+	border-collapse: collapse;
+}
 table td {
   border: 0;
   outline: 0;

--- a/lib/template/layout.html
+++ b/lib/template/layout.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><?php print $title; ?></title>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" media="all" href="layout.css" />
   <style>
     <?php print preg_replace('/\s\s+/', ' ', $style); ?>
@@ -29,7 +29,7 @@
         </div>
       </div>
     <?php endif; ?>
-    <table cellpadding="0" cellspacing="0">
+    <table>
       <thead>
         <tr>
           <th class="docs">

--- a/lib/template/layout.html
+++ b/lib/template/layout.html
@@ -1,41 +1,40 @@
 <!DOCTYPE html>
-
 <html>
 <head>
-  <title><?=$title?></title>
+  <title><?php print $title; ?></title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <link rel="stylesheet" media="all" href="layout.css" />
   <style>
-    <?=preg_replace('/\s\s+/', ' ',$style)?>
+    <?php print preg_replace('/\s\s+/', ' ', $style); ?>
   </style>
 </head>
 <body>
   <div id="container">
     <div id="background"></div>
-    <?if(count($sources)):?>
+    <?php if (count($sources)): ?>
       <div id="jump_to">
         Jump To &hellip;
         <div id="jump_wrapper">
           <div id="jump_page">
-            <?foreach($sources as $source):?>
-              <?if(substr_count($path, "/")===0):?>
-                <a class="source" href="./<?=$source["url"]?>">
-              <?else:?>
-              <a class="source" href="<?=str_repeat("../",substr_count($path, "/"))?><?=$source["url"]?>">
-              <?endif?>
-                <?=$source["name"]?>
+            <?php foreach ($sources as $source): ?>
+              <?php if (substr_count($path, "/")===0): ?>
+                <a class="source" href="./<?php print $source["url"]; ?>">
+              <?php else: ?>
+              <a class="source" href="<?php print str_repeat("../",substr_count($path, "/")); ?><?php print $source["url"]; ?>">
+              <?php endif; ?>
+                <?php print $source["name"]; ?>
               </a>
-            <?endforeach?>
+            <?php endforeach; ?>
           </div>
         </div>
       </div>
-    <?endif?>
+    <?php endif; ?>
     <table cellpadding="0" cellspacing="0">
       <thead>
         <tr>
           <th class="docs">
             <h1>
-              <?=$title?>
+              <?php print $title; ?>
             </h1>
           </th>
           <th class="code">
@@ -43,19 +42,19 @@
         </tr>
       </thead>
       <tbody>
-        <?foreach((array)$sections["docs"] as $count=>$section):?>
-          <tr id="section-<?=$count?>">
+        <?php foreach ((array)$sections["docs"] as $count=>$section): ?>
+          <tr id="section-<?php print $count; ?>">
             <td class="docs">
               <div class="pilwrap">
-                <a class="pilcrow" href="#section-<?=$count?>">&#182;</a>
+                <a class="pilcrow" href="#section-<?php print $count; ?>">&#182;</a>
               </div>
-              <?=$sections["docs"][$count]?>
+              <?php print $sections["docs"][$count]; ?>
             </td>
             <td class="code">
-              <?=$sections["code"][$count]?>
+              <?php print $sections["code"][$count]; ?>
             </td>
           </tr>
-        <?endforeach?>
+        <?php endforeach; ?>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
I've made these changes so I can use Phrocco on my development PHP environment, which has short tags disabled. PHP short tags are not often supported; these changes ensure that Phrocco is compatible with a wider variety of PHP installs, notably on the Mac OS X default install (which is what I'm using).

I also started to look at validating the HTML output as HTML5; I've tackled some of the smaller problems but there are a few that go deeper. One that's bugging me a lot is that there always seems to be an extra `</pre></div>` appended to the code. Run the output through the [W3 Validator](http://validator.w3.org/#validate_by_input) to see what I mean.
