### PR TITLE
Fix for Pygment.php (undefined variable)

### DIFF
--- a/lib/Pygment.php
+++ b/lib/Pygment.php
@@ -51,6 +51,8 @@ class Pygment
 
         $process = proc_open("pygmentize -l $language -f html", $descriptorspec, $pipes);
 
+        $parsed_code = '';
+
         if (is_resource($process)) {
             fwrite($pipes[0], ($code));
             fclose($pipes[0]);


### PR DESCRIPTION
PHP throws "PHP Notice: Undefined variable: parsed_code", this commit fix that problem.
